### PR TITLE
Added FB messenger module to testbot

### DIFF
--- a/testbot/botpress-messenger.config.yml
+++ b/testbot/botpress-messenger.config.yml
@@ -1,0 +1,32 @@
+# Edit this file to set the Messenger's module settings programmatically instead of using the GUI
+# This is regular YAML syntax. See http://docs.ansible.com/ansible/YAMLSyntax.html
+# You can override these settings with ENV variables. They are commented below.
+
+# hostname: "" # MESSENGER_HOST
+
+# applicationID: "" # MESSENGER_APP_ID
+# accessToken: "" # MESSENGER_ACCESS_TOKEN
+# appSecret: "" # MESSENGER_APP_SECRET
+
+# verifyToken: "" # MESSENGER_VERIFY_TOKEN
+
+# displayGetStarted: true
+# greetingMessage: ""
+
+# https://developers.facebook.com/docs/messenger-platform/messenger-profile/persistent-menu
+# persistentMenuItems: []
+
+# targetAudience: openToAll
+# targetAudienceOpenToSome: ""
+# targetAudienceCloseToSome: ""
+
+# trustedDomains: []
+# autoRespondGetStarted: true
+
+# paymentTesters: []
+
+# chatExtensionHomeUrl: ""
+# chatExtensionInTest: true
+# chatExtensionShowShareButton: false
+
+enabled: true

--- a/testbot/package-lock.json
+++ b/testbot/package-lock.json
@@ -196,6 +196,16 @@
       "resolved": "https://registry.npmjs.org/botpress/-/botpress-1.0.28.tgz",
       "integrity": "sha512-U4BXzrcRRHeuVwaJnYZB2Rg6uD2m0Hep0cikO+RI7lG5FjHXsneu6KoQccZVlbMZX3MmQARX6W9k5NduVu0wsA=="
     },
+    "botpress-messenger": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/botpress-messenger/-/botpress-messenger-2.2.9.tgz",
+      "integrity": "sha512-GUh95HQqEhYNeN8YpQwxcDGmMSwFYMNVwzoTRF+UrF7kNvyCQVfpne7U1U+/+QxWvwCi2ybQLA/gP4a00ENz1w=="
+    },
+    "botpress-version-manager": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/botpress-version-manager/-/botpress-version-manager-1.0.4.tgz",
+      "integrity": "sha1-U7On7oQhdr+/dvdTBKBryodELKU="
+    },
     "botpress-web": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/botpress-web/-/botpress-web-1.2.3.tgz",
@@ -669,6 +679,11 @@
           "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         }
       }
+    },
+    "fetch-jsonp": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.1.3.tgz",
+      "integrity": "sha1-nrnlhboIqvcAVjU40Xu+u81aPbI="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1200,6 +1215,11 @@
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.5.tgz",
       "integrity": "sha1-mYwods/0hLED5EI7k9NW2kRzTJE="
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -1254,6 +1274,11 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -1739,10 +1764,20 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k="
     },
+    "react-audio-player": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/react-audio-player/-/react-audio-player-0.5.0.tgz",
+      "integrity": "sha1-wTvnz7wJ5GUDtErEKgQ+SNyVLlw="
+    },
     "react-codemirror": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-codemirror/-/react-codemirror-1.0.0.tgz",
       "integrity": "sha1-kUZ7U7H12A2Rai/QtMetuFqQAbo="
+    },
+    "react-player": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-0.18.0.tgz",
+      "integrity": "sha1-ILP/z6qYyPLb3hbyS2NZ82fd9OA="
     },
     "read": {
       "version": "1.0.7",

--- a/testbot/package.json
+++ b/testbot/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "botpress": "1.x",
+    "botpress-messenger": "^2.2.9",
     "botpress-web": "1.x"
   },
   "scripts": {


### PR DESCRIPTION
Added FB messenger module to our bot using the following instructions:
https://www.youtube.com/watch?v=HTpUmDz9kRY

Added the bot via the bot dashboard, accessible at
http://localhost:3000 after running `bp start` from within the `/testbot`
folder.

Module appears in the dash and clicking on it brings up its config page.

Next step is to configure the module and connect it to an FB page
with the appropriate developer/API keys.

Responds to Issue #2.